### PR TITLE
Check for $USER

### DIFF
--- a/papirus-folders
+++ b/papirus-folders
@@ -165,6 +165,8 @@ get_user() {
 		user="$(id -nu "$PKEXEC_UID")"
 	elif [ -n "$SUDO_USER" ]; then
 		user="$SUDO_USER"
+	elif [ -n "$USER" ]; then
+		user="$USER"
 	elif [ -n "$LOGNAME" ]; then
 		user="$LOGNAME"
 	else


### PR DESCRIPTION
When determining user, check for $USER. Without this, an issue can occur in environments that do not correctly set LOGNAME.